### PR TITLE
Change assumption in the `wait` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # async.nvim
 Small async library for Neovim plugins
 
+[API documentation](async.md)
+
 ## Example
 
 Take the current function that uses a callback style function to run a system process.
@@ -19,8 +21,8 @@ end
 
 If we want to emulate something like:
 
-```lua
-echo foo && echo bar && echo baz
+```bash
+echo 'foo' && echo 'bar' && echo 'baz'
 ```
 
 Would need to be implemented as:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ local run_job_a = a.wrap(run_job, 3)
 
 Now we need to create a top level function to initialize the async context. To do this we can use `void` or `sync`.
 
-Note: the main difference between `void` and `sync` is that `sync` functions can be called with a callback, like the original `run_job` in a non-async context, however the user must provide the number of agurments.
+Note: the main difference between `void` and `sync` is that `sync` functions can be called with a callback, like the original `run_job` in a non-async context, however the user must provide the number of arguments.
 
 For this example we will use `void`:
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ local run_job_a = a.wrap(run_job, 3)
 
 Now we need to create a top level function to initialize the async context. To do this we can use `void` or `sync`.
 
-Note: the main difference between `void` and `sync` is that `sync` functions can be called with a callback (like the `run_job` in a non-async context, however the user must provide the number of agurments.
+Note: the main difference between `void` and `sync` is that `sync` functions can be called with a callback, like the original `run_job` in a non-async context, however the user must provide the number of agurments.
 
 For this example we will use `void`:
 

--- a/async.md
+++ b/async.md
@@ -5,6 +5,12 @@ Small async library for Neovim plugins
 
 ## Functions
 
+### `running()`
+
+Returns whether the current execution context is async.
+
+
+---
 ### `create(func, argc)`
 
 Use this to create a function which executes in an async context but

--- a/async.md
+++ b/async.md
@@ -36,7 +36,7 @@ Wait on a callback style function
 
 #### Parameters:
 
-* `argc` (`integer?`):  The number of arguments of func. Must be included.
+* `argc` (`integer?`):  The number of arguments of func.
 * `func` (`function`):  callback style function to execute
 * `...` (`any`):  Arguments for func
 

--- a/async.md
+++ b/async.md
@@ -44,16 +44,16 @@ Creates an async function with a callback style function.
 * `protected` (`boolean`):  call the function in protected mode (like pcall)
 
 ---
-### `join(n, interrupt_check, thunks)`
+### `join(thunks, n, interrupt_check)`
 
 Run a collection of async functions (`thunks`) concurrently and return when
  all have finished.
 
 #### Parameters:
 
+* `thunks` (`function[]`):
 * `n` (`integer`):  Max number of thunks to run concurrently
 * `interrupt_check` (`function`):  Function to abort thunks between calls
-* `thunks` (`function[]`):
 
 ---
 ### `curry(fn, ...)`

--- a/async.md
+++ b/async.md
@@ -10,6 +10,10 @@ Small async library for Neovim plugins
 Returns whether the current execution context is async.
 
 
+#### Returns
+
+  `boolean?`
+
 ---
 ### `run(func, callback, ...)`
 
@@ -20,6 +24,10 @@ Run a function in an async context.
 * `func` (`function`):
 * `callback` (`function`):
 * `...` (`any`):  Arguments for func
+
+#### Returns
+
+  `async_t`: Handle
 
 ---
 ### `wait(argc, protected, func, ...)`
@@ -46,6 +54,10 @@ Use this to create a function which executes in an async context but
 * `argc` (`number`):  The number of arguments of func. Defaults to 0
 * `strict` (`boolean`):  Error when called in non-async context
 
+#### Returns
+
+  `function(...):async_t`
+
 ---
 ### `void(func, strict)`
 
@@ -71,6 +83,10 @@ Creates an async function with a callback style function.
 * `argc` (`integer`):  The number of arguments of func. Must be included.
 * `protected` (`boolean`):  call the function in protected mode (like pcall)
 * `strict` (`boolean`):  Error when called in non-async context
+
+#### Returns
+
+  `function`: Returns an async function
 
 ---
 ### `join(thunks, n, interrupt_check)`

--- a/async.md
+++ b/async.md
@@ -30,14 +30,13 @@ Run a function in an async context.
   `async_t`: Handle
 
 ---
-### `wait(argc, protected, func, ...)`
+### `wait(argc, func, ...)`
 
 Wait on a callback style function
 
 #### Parameters:
 
 * `argc` (`integer?`):  The number of arguments of func. Must be included.
-* `protected` (`boolean?`):  call the function in protected mode (like pcall)
 * `func` (`function`):  callback style function to execute
 * `...` (`any`):  Arguments for func
 
@@ -73,9 +72,6 @@ Create a function which executes in an async context but
 ### `wrap(func, argc, protected, strict)`
 
 Creates an async function with a callback style function.
-
- TODO(lewis6991): Remove protected
-
 
 #### Parameters:
 

--- a/async.md
+++ b/async.md
@@ -11,7 +11,30 @@ Returns whether the current execution context is async.
 
 
 ---
-### `create(func, argc)`
+### `run(func, callback, ...)`
+
+Run a function in an async context.
+
+#### Parameters:
+
+* `func` (`function`):
+* `callback` (`function`):
+* `...` (`any`):  Arguments for func
+
+---
+### `wait(argc, protected, func, ...)`
+
+Wait on a callback style function
+
+#### Parameters:
+
+* `argc` (`integer?`):  The number of arguments of func. Must be included.
+* `protected` (`boolean?`):  call the function in protected mode (like pcall)
+* `func` (`function`):  callback style function to execute
+* `...` (`any`):  Arguments for func
+
+---
+### `create(func, argc, strict)`
 
 Use this to create a function which executes in an async context but
  called from a non-async context.  Inherently this cannot return anything
@@ -21,9 +44,10 @@ Use this to create a function which executes in an async context but
 
 * `func` (`function`):
 * `argc` (`number`):  The number of arguments of func. Defaults to 0
+* `strict` (`boolean`):  Error when called in non-async context
 
 ---
-### `void(func)`
+### `void(func, strict)`
 
 Create a function which executes in an async context but
  called from a non-async context.
@@ -31,17 +55,22 @@ Create a function which executes in an async context but
 #### Parameters:
 
 * `func` (`function`):
+* `strict` (`boolean`):  Error when called in non-async context
 
 ---
-### `wrap(func, argc, protected)`
+### `wrap(func, argc, protected, strict)`
 
 Creates an async function with a callback style function.
+
+ TODO(lewis6991): Remove protected
+
 
 #### Parameters:
 
 * `func` (`function`):  A callback style function to be converted. The last argument must be the callback.
 * `argc` (`integer`):  The number of arguments of func. Must be included.
 * `protected` (`boolean`):  call the function in protected mode (like pcall)
+* `strict` (`boolean`):  Error when called in non-async context
 
 ---
 ### `join(thunks, n, interrupt_check)`

--- a/async.md
+++ b/async.md
@@ -5,7 +5,7 @@ Small async library for Neovim plugins
 
 ## Functions
 
-### `sync(func, argc)`
+### `create(func, argc)`
 
 Use this to create a function which executes in an async context but
  called from a non-async context.  Inherently this cannot return anything

--- a/ldoc.ltp
+++ b/ldoc.ltp
@@ -43,6 +43,25 @@ $(lev3) $(subnames):
 >         end
 >       end -- for
 >     end -- if params
+> if item.retgroups then
+
+$(lev3) Returns
+
+>   for _, group in ldoc.ipairs(item.retgroups) do
+>     for r in group:iter() do
+>       local type, ctypes = item:return_type(r)
+>       if type ~= '' then
+>         if r.text ~= '' then
+  `$(type)`: $(r.text)
+>         else
+  `$(type)`
+>         end
+>       else
+  $(r.text)
+>       end
+>     end
+>   end
+> end
 
 ---
 >   end

--- a/lua/async.lua
+++ b/lua/async.lua
@@ -194,7 +194,6 @@ end
 ---
 --- @tparam function func A callback style function to be converted. The last argument must be the callback.
 --- @tparam integer argc The number of arguments of func. Must be included.
---- @tparam boolean protected call the function in protected mode (like pcall)
 --- @tparam boolean strict Error when called in non-async context
 --- @treturn function Returns an async function
 function M.wrap(func, argc, strict)

--- a/lua/async.lua
+++ b/lua/async.lua
@@ -109,7 +109,7 @@ local function wait(argc, func, ...)
   }
 
   -- Always run the wrapped functions in xpcall and re-raise the error in the
-  -- coroutine
+  -- coroutine. This makes pcall work as normal.
   local function pfunc(...)
     local args = { ... }
     local cb = args[argc]
@@ -134,7 +134,7 @@ end
 
 --- Wait on a callback style function
 ---
---- @tparam integer? argc The number of arguments of func. Must be included.
+--- @tparam integer? argc The number of arguments of func.
 --- @tparam function func callback style function to execute
 --- @tparam any ... Arguments for func
 function M.wait(...)
@@ -142,6 +142,7 @@ function M.wait(...)
     return wait(...)
   end
 
+  -- Asume argc is equal to the number of passed arguments.
   return wait(select('#', ...) - 1, ...)
 end
 

--- a/lua/async.lua
+++ b/lua/async.lua
@@ -68,12 +68,6 @@ function M.run(func, callback, ...)
     return cur_exec_handle and cur_exec_handle:is_cancelled()
   end
 
-  local function set_executing_handle(h)
-    if is_async_handle(h) then
-      cur_exec_handle = h
-    end
-  end
-
   setmetatable(handle, { __index = handle })
   handles[co] = handle
 
@@ -97,7 +91,11 @@ function M.run(func, callback, ...)
 
     local args = {select(5, unpack(ret))}
     args[nargs] = step
-    set_executing_handle(err_or_fn(unpack(args, 1, nargs)))
+
+    local r = err_or_fn(unpack(args, 1, nargs))
+    if is_async_handle(r) then
+      cur_exec_handle = r
+    end
   end
 
   step(...)

--- a/lua/async.lua
+++ b/lua/async.lua
@@ -82,7 +82,7 @@ function M.run(func, callback, ...)
 
     if coroutine.status(co) == 'dead' then
       if callback then
-        callback(unpack(ret, 4))
+        callback(unpack(ret, 4, table.maxn(ret)))
       end
       return
     end
@@ -129,7 +129,7 @@ local function wait(argc, func, ...)
     error(string.format("Wrapped function failed: %s\n%s", err, traceback))
   end
 
-  return unpack(ret, 2)
+  return unpack(ret, 2, table.maxn(ret))
 end
 
 --- Wait on a callback style function

--- a/lua/async.lua
+++ b/lua/async.lua
@@ -62,9 +62,9 @@ end
 --- @tparam any ... Arguments for func
 --- @treturn async_t Handle
 function M.run(func, callback, ...)
-  vim.validate{
+  vim.validate {
     func = { func, 'function' },
-    callback = { callback , 'function', true }
+    callback = { callback, 'function', true }
   }
 
   local co = coroutine.create(func)
@@ -105,8 +105,8 @@ function M.run(func, callback, ...)
 end
 
 local function wait(argc, func, ...)
-  vim.validate{
-    argc = { argc, 'number'},
+  vim.validate {
+    argc = { argc, 'number' },
     func = { func, 'function' },
   }
 
@@ -156,7 +156,7 @@ end
 --- @tparam boolean strict Error when called in non-async context
 --- @treturn function(...):async_t
 function M.create(func, argc, strict)
-  vim.validate{
+  vim.validate {
     func = { func, 'function' },
     argc = { argc, 'number', true }
   }
@@ -168,7 +168,7 @@ function M.create(func, argc, strict)
       end
       return func(...)
     end
-    local callback = select(argc+1, ...)
+    local callback = select(argc + 1, ...)
     return M.run(func, callback, unpack({...}, 1, argc))
   end
 end
@@ -178,7 +178,7 @@ end
 --- @tparam function func
 --- @tparam boolean strict Error when called in non-async context
 function M.void(func, strict)
-  vim.validate{ func = { func , 'function' } }
+  vim.validate { func = { func, 'function' } }
   return function(...)
     if M.running() then
       if strict then
@@ -197,7 +197,7 @@ end
 --- @tparam boolean strict Error when called in non-async context
 --- @treturn function Returns an async function
 function M.wrap(func, argc, strict)
-  vim.validate{
+  vim.validate {
     argc = { argc, 'number' },
   }
   return function(...)
@@ -228,7 +228,7 @@ function M.join(thunks, n, interrupt_check)
     local ret = {}
 
     local function cb(...)
-      ret[#ret+1] = {...}
+      ret[#ret + 1] = {...}
       to_go = to_go - 1
       if to_go == 0 then
         finish(ret)
@@ -260,7 +260,7 @@ function M.curry(fn, ...)
   return function(...)
     local other = {...}
     for i = 1, select('#', ...) do
-      args[nargs+i] = other[i]
+      args[nargs + i] = other[i]
     end
     fn(unpack(args))
   end

--- a/lua/async.lua
+++ b/lua/async.lua
@@ -140,12 +140,13 @@ end
 --- @tparam function func callback style function to execute
 --- @tparam any ... Arguments for func
 function M.wait(...)
-  if type(select(1, ...)) == 'number' then
+  if type(...) == 'number' then
     return wait(...)
+  else
+    -- Assume argc is equal to the number of passed arguments (- 1 for function
+    -- that is first argument, + 1 for callback that hasn't been passed).
+    return wait(select('#', ...), ...)
   end
-
-  -- Asume argc is equal to the number of passed arguments.
-  return wait(select('#', ...) - 1, ...)
 end
 
 --- Use this to create a function which executes in an async context but

--- a/lua/async.lua
+++ b/lua/async.lua
@@ -140,26 +140,11 @@ end
 --- @tparam function func callback style function to execute
 --- @tparam any ... Arguments for func
 function M.wait(...)
-  local nargs, args = select('#', ...), {...}
-
-  local argstart
-  local argc
-  for i = 1, math.min(nargs, 3) do
-    if type(args[i]) == 'function' then
-      argstart = i + 1
-      break
-    end
-    if type(args[i]) == 'number' then
-      argc = args[i]
-    end
+  if type(select(1, ...)) == 'number' then
+    return wait(...)
   end
 
-  assert(argstart)
-
-  local func = args[argstart - 1]
-  argc = argc or nargs - argstart + 1
-
-  return wait(argc, func, unpack(args, argstart, nargs))
+  return wait(select('#', ...) - 1, ...)
 end
 
 --- Use this to create a function which executes in an async context but

--- a/lua/async.lua
+++ b/lua/async.lua
@@ -58,7 +58,7 @@ end
 --- since it is non-blocking
 --- @tparam function func
 --- @tparam number argc The number of arguments of func. Defaults to 0
-function M.sync(func, argc)
+function M.create(func, argc)
   argc = argc or 0
   return function(...)
     if coroutine.running() ~= main_co_or_nil then

--- a/lua/async.lua
+++ b/lua/async.lua
@@ -165,10 +165,10 @@ end
 
 --- Run a collection of async functions (`thunks`) concurrently and return when
 --- all have finished.
+--- @tparam function[] thunks
 --- @tparam integer n Max number of thunks to run concurrently
 --- @tparam function interrupt_check Function to abort thunks between calls
---- @tparam function[] thunks
-function M.join(n, interrupt_check, thunks)
+function M.join(thunks, n, interrupt_check )
   local function run(finish)
     if #thunks == 0 then
       return finish()

--- a/lua/async.lua
+++ b/lua/async.lua
@@ -27,7 +27,7 @@ function M.running()
 end
 
 local function is_async_handle(handle)
-  if handle and handle.cancel and handle.is_cancelled then
+  if handle and vim.is_callable(handle.cancel) and vim.is_callable(handle.is_cancelled) then
     return true
   end
 end

--- a/lua/async.lua
+++ b/lua/async.lua
@@ -18,7 +18,7 @@ local M = {}
 
 --- Returns whether the current execution context is async.
 ---
---- @return boolean|nil
+--- @treturn boolean?
 function M.running()
   local current = coroutine.running()
   if current and handles[current] then
@@ -36,6 +36,7 @@ end
 --- @tparam function func
 --- @tparam function callback
 --- @tparam any ... Arguments for func
+--- @treturn async_t Handle
 function M.run(func, callback, ...)
   vim.validate{
     func = { func, 'function' },
@@ -164,6 +165,7 @@ end
 --- @tparam function func
 --- @tparam number argc The number of arguments of func. Defaults to 0
 --- @tparam boolean strict Error when called in non-async context
+--- @treturn function(...):async_t
 function M.create(func, argc, strict)
   vim.validate{
     func = { func, 'function' },
@@ -207,7 +209,7 @@ end
 --- @tparam integer argc The number of arguments of func. Must be included.
 --- @tparam boolean protected call the function in protected mode (like pcall)
 --- @tparam boolean strict Error when called in non-async context
---- @return function Returns an async function
+--- @treturn function Returns an async function
 function M.wrap(func, argc, protected, strict)
   vim.validate{
     argc = { argc, 'number' },


### PR DESCRIPTION
Make `wait` work the next way

```lua
local function f(p1, p2, callback) ... end

async.wait(f, p1, p2)
```
So on call `wait` function without first `argc` argument, the `wait` function will assume, that the number of arguments is equal to number of passed arguments + 1 for callback, that hasn't been passed.